### PR TITLE
Remove fortify from require

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FortifyUI is an unopinionated authentication starter, powered by [Laravel Fortif
 To get started, you'll need to install [Laravel Fortify](https://github.com/laravel/fortify) and follow the instructions to configure it. Next, install FortifyUI using Composer:
 
 ```bash
-composer require zacksmash/fortify-ui laravel/fortify
+composer require zacksmash/fortify-ui
 ```
 
 Next, publish FortifyUI's resources:


### PR DESCRIPTION
Remove the fortify from the composer require command as you've stated above it should be installed an configured already, this threw off my install.