### PR TITLE
Capitalize Providers

### DIFF
--- a/src/Commands/FortifyUICommand.php
+++ b/src/Commands/FortifyUICommand.php
@@ -85,7 +85,7 @@ class FortifyUICommand extends Command
         );
 
         File::put(
-            app_path('providers/RouteServiceProvider.php'),
+            app_path('Providers/RouteServiceProvider.php'),
             str_replace(
                 "public const HOME = '/home';",
                 "public const HOME = '/dashboard';",


### PR DESCRIPTION
The providers path/class must be capitalized in order to work. This is a fix for #19