### PR TITLE
Fix missing 2FA confirmation step

### DIFF
--- a/stubs/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/resources/views/profile/two-factor-authentication-form.blade.php
@@ -21,24 +21,49 @@
     @if(session('status') == 'two-factor-authentication-enabled')
         {{-- Show SVG QR Code, After Enabling 2FA --}}
         <div>
-            {{ __('Two factor authentication is now enabled. Scan the following QR code using your phone\'s authenticator application.') }}
+            {{ __('Two factor authentication is now enabled. Please finish configuring two factor authentication below.') }}
         </div>
 
         <div>
-            {!! auth()->user()->twoFactorQrCodeSvg() !!}
+            {{ __('Scan the QR code using your phone’s authenticator application, or click it to use an authenticator application on your current device.') }}
         </div>
+
+        <div>
+            <a href="{!! auth()->user()->twoFactorQrCodeUrl() !!}" rel="alternate" aria-label="2FA link">{!! auth()->user()->twoFactorQrCodeSvg() !!}</a>
+        </div>
+
+        <form method="POST" action="{{ route('two-factor.confirm') }}">
+            @csrf
+
+            <div>
+                <label>{{ __('Enter current 2FA code from your authenticator application to confirm the setup has been successful.') }}</label>
+                <input type="text" name="code" required autofocus autocomplete="off" />
+            </div>
+
+            <button type="submit">
+                {{ __('Confirm 2FA code') }}
+            </button>
+        </form>
+
+        {{-- Show 2FA Recovery Codes --}}
+        <div>
+            {{ __('Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.') }}
+        </div>
+
+        <div>
+            @foreach (json_decode(decrypt(auth()->user()->two_factor_recovery_codes), true) as $code)
+                <div>{{ $code }}</div>
+            @endforeach
+        </div>
+
     @endif
 
-    {{-- Show 2FA Recovery Codes --}}
-    <div>
-        {{ __('Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.') }}
-    </div>
-
-    <div>
-        @foreach (json_decode(decrypt(auth()->user()->two_factor_recovery_codes), true) as $code)
-            <div>{{ $code }}</div>
-        @endforeach
-    </div>
+    @if (session('status') == 'two-factor-authentication-confirmed')
+        {{-- Show Confirmation Sucess, After 2FA Confirmation Code Entered Correctly --}}
+        <div>
+            Two factor authentication confirmed and enabled successfully.
+        </div>
+    @endif
 
     {{-- Regenerate 2FA Recovery Codes --}}
     <form method="POST" action="{{ route('two-factor.recovery-codes') }}">
@@ -48,5 +73,6 @@
             {{ __('Regenerate Recovery Codes') }}
         </button>
     </form>
+
 @endif
 <hr>

--- a/stubs/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/stubs/resources/views/profile/two-factor-authentication-form.blade.php
@@ -50,12 +50,6 @@
             {{ __('Store these recovery codes in a secure password manager. They can be used to recover access to your account if your two factor authentication device is lost.') }}
         </div>
 
-        <div>
-            @foreach (json_decode(decrypt(auth()->user()->two_factor_recovery_codes), true) as $code)
-                <div>{{ $code }}</div>
-            @endforeach
-        </div>
-
     @endif
 
     @if (session('status') == 'two-factor-authentication-confirmed')
@@ -64,6 +58,11 @@
             Two factor authentication confirmed and enabled successfully.
         </div>
     @endif
+    <div>
+        @foreach (json_decode(decrypt(auth()->user()->two_factor_recovery_codes), true) as $code)
+            <div>{{ $code }}</div>
+        @endforeach
+    </div>
 
     {{-- Regenerate 2FA Recovery Codes --}}
     <form method="POST" action="{{ route('two-factor.recovery-codes') }}">
@@ -75,4 +74,6 @@
     </form>
 
 @endif
+
+
 <hr>


### PR DESCRIPTION
(This is my first GitHub pull request, so please let me know if I’ve done something incorrectly.)

2FA authentication was not becoming activated (tested in Laravel 12) due to a missing confirmation step, outlined in the Laravel documentation: [Confirming Two Factor Authentication](https://laravel.com/docs/12.x/fortify#confirming-two-factor-authentication).

The `two-factor-authentication-form.blade.php` has been modified:

1. To include an additional form for sending a confirmation code to the `/user/confirmed-two-factor-authentication` endpoint defined by Fortify (route `two-factor.confirm`).
4. A link has been added to the QR code so that users of authenticator applications on desktop devices (such as the MacOS Passwords service) can click the code and setup 2FA on their local device.
